### PR TITLE
Adding box-shadow property, removing '$0' and adding max-(width/height)

### DIFF
--- a/snippets/css-snippets.cson
+++ b/snippets/css-snippets.cson
@@ -221,6 +221,12 @@
   'min-width':
     'prefix': 'mw'
     'body': 'min-width: ${1:${2:1}${3:px}}'
+  'max-height':
+    'prefix': 'maxh'
+    'body': 'max-height: ${1:${2:1}${3:px}}'
+  'max-width':
+    'prefix': 'maxw'
+    'body': 'max-width: ${1:${2:1}${3:px}}'
   'overflow':
     'prefix': 'ov'
     'body': 'overflow: ${1:hidden}'
@@ -568,6 +574,12 @@
   'min-width':
     'prefix': 'mw'
     'body': 'min-width: ${1:${2:1}${3:px}};'
+  'max-height':
+    'prefix': 'maxh'
+    'body': 'max-height: ${1:${2:1}${3:px}}'
+  'max-width':
+    'prefix': 'maxw'
+    'body': 'max-width: ${1:${2:1}${3:px}}'
   'overflow':
     'prefix': 'ov'
     'body': 'overflow: ${1:hidden};'

--- a/snippets/css-snippets.cson
+++ b/snippets/css-snippets.cson
@@ -72,8 +72,11 @@
     'prefix': 'bot'
     'body': 'bottom: ${1:0}'
   'box-shadow':
-    'prefix': 'boxs'
-    'body': 'box-shadow: ${1:0px} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0,0,0,.5)};$0     // h-length, v-length, blur, spread, colour'
+    'prefix': 'bs'
+    'body': """
+        // h-length, v-length, blur, spread, colour
+        box-shadow: ${1:0} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0, 0, 0, .5)}$0
+    """
   'clear':
     'prefix': 'clr'
     'body': 'clear: ${1:both}'
@@ -216,16 +219,16 @@
     'prefix': 'mart'
     'body': 'margin-top: ${1:${2:1}${3:px}}'
   'min-height':
-    'prefix': 'mh'
+    'prefix': 'mih'
     'body': 'min-height: ${1:${2:1}${3:px}}'
   'min-width':
-    'prefix': 'mw'
+    'prefix': 'miw'
     'body': 'min-width: ${1:${2:1}${3:px}}'
   'max-height':
-    'prefix': 'maxh'
+    'prefix': 'mah'
     'body': 'max-height: ${1:${2:1}${3:px}}'
   'max-width':
-    'prefix': 'maxw'
+    'prefix': 'maw'
     'body': 'max-width: ${1:${2:1}${3:px}}'
   'overflow':
     'prefix': 'ov'
@@ -425,8 +428,11 @@
     'prefix': 'bot'
     'body': 'bottom: ${1:0};'
   'box-shadow':
-    'prefix': 'boxs'
-    'body': 'box-shadow: ${1:0px} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0,0,0,.5)};$0     // h-length, v-length, blur, spread, colour'
+    'prefix': 'bs'
+    'body': """
+        // h-length, v-length, blur, spread, colour
+        box-shadow: ${1:0} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0, 0, 0, .5)}$0
+    """
   'clear':
     'prefix': 'clr'
     'body': 'clear: ${1:both};'
@@ -569,17 +575,17 @@
     'prefix': 'mart'
     'body': 'margin-top: ${1:${2:1}${3:px}};'
   'min-height':
-    'prefix': 'mh'
+    'prefix': 'mih'
     'body': 'min-height: ${1:${2:1}${3:px}};'
   'min-width':
-    'prefix': 'mw'
+    'prefix': 'miw'
     'body': 'min-width: ${1:${2:1}${3:px}};'
   'max-height':
-    'prefix': 'maxh'
-    'body': 'max-height: ${1:${2:1}${3:px}}'
+    'prefix': 'mah'
+    'body': 'max-height: ${1:${2:1}${3:px}};'
   'max-width':
-    'prefix': 'maxw'
-    'body': 'max-width: ${1:${2:1}${3:px}}'
+    'prefix': 'maw'
+    'body': 'max-width: ${1:${2:1}${3:px}};'
   'overflow':
     'prefix': 'ov'
     'body': 'overflow: ${1:hidden};'

--- a/snippets/css-snippets.cson
+++ b/snippets/css-snippets.cson
@@ -71,6 +71,9 @@
   'bottom':
     'prefix': 'bot'
     'body': 'bottom: ${1:0}$0'
+  'box-shadow':
+    'prefix': 'boxs'
+    'body': 'box-shadow: ${1:0px} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0,0,0,.5)};$0     // h-length, v-length, blur, spread, colour'
   'clear':
     'prefix': 'clr'
     'body': 'clear: ${1:both}$0'
@@ -415,6 +418,9 @@
   'bottom':
     'prefix': 'bot'
     'body': 'bottom: ${1:0};$0'
+  'box-shadow':
+    'prefix': 'boxs'
+    'body': 'box-shadow: ${1:0px} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0,0,0,.5)};$0     // h-length, v-length, blur, spread, colour'
   'clear':
     'prefix': 'clr'
     'body': 'clear: ${1:both};$0'

--- a/snippets/css-snippets.cson
+++ b/snippets/css-snippets.cson
@@ -85,7 +85,7 @@
     'body': 'color: ${1:#${2:000000}}'
   'content':
     'prefix': 'con'
-    'body': "content: '$1'$0"
+    'body': "content: '$1'"
   'cursor':
     'prefix': 'cur'
     'body': 'cursor: ${1:pointer}'
@@ -441,7 +441,7 @@
     'body': 'color: ${1:#${2:000000}};'
   'content':
     'prefix': 'con'
-    'body': "content: '$1';$0"
+    'body': "content: '$1';"
   'cursor':
     'prefix': 'cur'
     'body': 'cursor: ${1:pointer};'

--- a/snippets/css-snippets.cson
+++ b/snippets/css-snippets.cson
@@ -75,7 +75,7 @@
     'prefix': 'bs'
     'body': """
         // h-length, v-length, blur, spread, colour
-        box-shadow: ${1:0} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0, 0, 0, .5)}$0
+        box-shadow: ${1:0} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0, 0, 0, .5)}
     """
   'clear':
     'prefix': 'clr'
@@ -431,7 +431,7 @@
     'prefix': 'bs'
     'body': """
         // h-length, v-length, blur, spread, colour
-        box-shadow: ${1:0} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0, 0, 0, .5)}$0
+        box-shadow: ${1:0} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0, 0, 0, .5)};
     """
   'clear':
     'prefix': 'clr'

--- a/snippets/css-snippets.cson
+++ b/snippets/css-snippets.cson
@@ -1,695 +1,695 @@
 '.source.sass, .source.css.sass':
   'background':
     'prefix': 'bg'
-    'body': 'background: ${1:#${2:ffffff}}$0'
+    'body': 'background: ${1:#${2:ffffff}}'
   'background-color':
     'prefix': 'bgc'
-    'body': 'background-color: ${1:#${2:ffffff}}$0'
+    'body': 'background-color: ${1:#${2:ffffff}}'
   'background-image':
     'prefix': 'bgi'
-    'body': 'background-image: ${2:url(\'${1:background.jpg}\')}$0'
+    'body': 'background-image: ${2:url(\'${1:background.jpg}\')}'
   'background-image (asset-url)':
     'prefix': 'bgia'
-    'body': 'background-image: ${2:asset-url(\'${1:background.jpg}\')}$0'
+    'body': 'background-image: ${2:asset-url(\'${1:background.jpg}\')}'
   'background-position':
     'prefix': 'bgp'
-    'body': 'background-position: ${1:left} ${2:top}$0'
+    'body': 'background-position: ${1:left} ${2:top}'
   'background-repeat':
     'prefix': 'bgr'
-    'body': 'background-repeat: ${1:repeat}$0'
+    'body': 'background-repeat: ${1:repeat}'
   'background-repeat: repeat':
     'prefix': 'bgrr'
-    'body': 'background-repeat: repeat$0'
+    'body': 'background-repeat: repeat'
   'background-repeat: repeat-x':
     'prefix': 'bgrx'
-    'body': 'background-repeat: repeat-x$0'
+    'body': 'background-repeat: repeat-x'
   'background-repeat: repeat-y':
     'prefix': 'bgry'
-    'body': 'background-repeat: repeat-y$0'
+    'body': 'background-repeat: repeat-y'
   'background-repeat: no-repeat':
     'prefix': 'bgrn'
-    'body': 'background-repeat: no-repeat$0'
+    'body': 'background-repeat: no-repeat'
   'border':
     'prefix': 'bor'
-    'body': 'border: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}}$0'
+    'body': 'border: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}}'
   'border-color':
     'prefix': 'borc'
-    'body': 'border-color: ${1:#${2:000}}$0'
+    'body': 'border-color: ${1:#${2:000}}'
   'border-style':
     'prefix': 'bors'
-    'body': 'border-style: ${3:solid}$0'
+    'body': 'border-style: ${3:solid}'
   'border-width':
     'prefix': 'borw'
-    'body': 'border-width: ${1:${2:1}${3:px}}$0'
+    'body': 'border-width: ${1:${2:1}${3:px}}'
   'border-bottom':
     'prefix': 'borb'
-    'body': 'border-bottom: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}}$0'
+    'body': 'border-bottom: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}}'
   'border-bottom-width':
     'prefix': 'borbw'
-    'body': 'border-bottom-width: ${1:${2:1}${3:px}}}$0'
+    'body': 'border-bottom-width: ${1:${2:1}${3:px}}}'
   'border-left':
     'prefix': 'borl'
-    'body': 'border-left: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}}$0'
+    'body': 'border-left: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}}'
   'border-left-width':
     'prefix': 'borlw'
-    'body': 'border-left-width: ${1:${2:1}${3:px}}$0'
+    'body': 'border-left-width: ${1:${2:1}${3:px}}'
   'border-right':
     'prefix': 'borr'
-    'body': 'border-right: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}}$0'
+    'body': 'border-right: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}}'
   'border-right-width':
     'prefix': 'borrw'
-    'body': 'border-right-width: ${1:${2:1}${3:px}}$0'
+    'body': 'border-right-width: ${1:${2:1}${3:px}}'
   'border-top':
     'prefix': 'bort'
-    'body': 'border-top: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}}$0'
+    'body': 'border-top: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}}'
   'border-top-width':
     'prefix': 'bortw'
-    'body': 'border-top-width: ${1:${2:1}${3:px}}$0'
+    'body': 'border-top-width: ${1:${2:1}${3:px}}'
   'border-radius':
     'prefix': 'br'
-    'body': 'border-radius: ${1:${2:1}${3:px}}$0'
+    'body': 'border-radius: ${1:${2:1}${3:px}}'
   'bottom':
     'prefix': 'bot'
-    'body': 'bottom: ${1:0}$0'
+    'body': 'bottom: ${1:0}'
   'box-shadow':
     'prefix': 'boxs'
     'body': 'box-shadow: ${1:0px} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0,0,0,.5)};$0     // h-length, v-length, blur, spread, colour'
   'clear':
     'prefix': 'clr'
-    'body': 'clear: ${1:both}$0'
+    'body': 'clear: ${1:both}'
   'color':
     'prefix': 'col'
-    'body': 'color: ${1:#${2:000000}}$0'
+    'body': 'color: ${1:#${2:000000}}'
   'content':
     'prefix': 'con'
     'body': "content: '$1'$0"
   'cursor':
     'prefix': 'cur'
-    'body': 'cursor: ${1:pointer}$0'
+    'body': 'cursor: ${1:pointer}'
   'cursor: pointer':
     'prefix': 'curp'
-    'body': 'cursor: pointer$0'
+    'body': 'cursor: pointer'
   'cursor: default':
     'prefix': 'curd'
-    'body': 'cursor: default$0'
+    'body': 'cursor: default'
   'cursor: inherit':
     'prefix': 'curi'
-    'body': 'cursor: inherit$0'
+    'body': 'cursor: inherit'
   'display':
     'prefix': 'dis'
-    'body': 'display: ${1:none}$0'
+    'body': 'display: ${1:none}'
   'display: block':
     'prefix': 'disb'
-    'body': 'display: block$0'
+    'body': 'display: block'
   'display: inline-block':
     'prefix': 'disi'
-    'body': 'display: inline-block$0'
+    'body': 'display: inline-block'
   'display: none':
     'prefix': 'disn'
-    'body': 'display: none$0'
+    'body': 'display: none'
   'display: flex':
     'prefix': 'disf'
-    'body': 'display: flex$0'
+    'body': 'display: flex'
   'fill':
     'prefix': 'fill'
-    'body': 'fill: ${1:#${2:000000}}$0'
+    'body': 'fill: ${1:#${2:000000}}'
   'float':
     'prefix': 'fl'
-    'body': 'float: ${1:left}$0'
+    'body': 'float: ${1:left}'
   'float: left':
     'prefix': 'fll'
-    'body': 'float: left$0'
+    'body': 'float: left'
   'float: right':
     'prefix': 'flr'
-    'body': 'float: right$0'
+    'body': 'float: right'
   'float: none':
     'prefix': 'fln'
-    'body': 'float: none$0'
+    'body': 'float: none'
   'font-family':
     'prefix': 'ff'
-    'body': 'font-family: ${1:arial}$0'
+    'body': 'font-family: ${1:arial}'
   'font-size':
     'prefix': 'fs'
-    'body': 'font-size: ${1:${2:1}${3:px}}$0'
+    'body': 'font-size: ${1:${2:1}${3:px}}'
   'font-style':
     'prefix': 'fst'
-    'body': 'font-style: ${1:italic}$0'
+    'body': 'font-style: ${1:italic}'
   'font-style: italic':
     'prefix': 'fsti'
-    'body': 'font-style: italic$0'
+    'body': 'font-style: italic'
   'font-style: normal':
     'prefix': 'fstn'
-    'body': 'font-style: normal$0'
+    'body': 'font-style: normal'
   'font-style: bold':
     'prefix': 'fstb'
-    'body': 'font-style: bold$0'
+    'body': 'font-style: bold'
   'font-weight':
     'prefix': 'fw'
-    'body': 'font-weight: ${1:bold}$0'
+    'body': 'font-weight: ${1:bold}'
   'font-weight: bold':
     'prefix': 'fwb'
-    'body': 'font-weight: bold$0'
+    'body': 'font-weight: bold'
   'font-weight: light':
     'prefix': 'fwl'
-    'body': 'font-weight: light$0'
+    'body': 'font-weight: light'
   'font-weight: normal':
     'prefix': 'fwn'
-    'body': 'font-weight: normal$0'
+    'body': 'font-weight: normal'
   'height':
     'prefix': 'hei'
-    'body': 'height: ${1:${2:1}${3:px}}$0'
+    'body': 'height: ${1:${2:1}${3:px}}'
   'height: auto':
     'prefix': 'heia'
-    'body': 'height: auto$0'
+    'body': 'height: auto'
   'list-style':
     'prefix': 'lis'
-    'body': 'list-style: ${1:square} ${2:inside} ${4:url(\'${3:list.png}\')}$0'
+    'body': 'list-style: ${1:square} ${2:inside} ${4:url(\'${3:list.png}\')}'
   'list-style-type':
     'prefix': 'list'
-    'body': 'list-style-type: ${1:circle}$0'
+    'body': 'list-style-type: ${1:circle}'
   'list-style-type: circle':
     'prefix': 'listc'
-    'body': 'list-style-type: circle$0'
+    'body': 'list-style-type: circle'
   'list-style-type: disc':
     'prefix': 'listd'
-    'body': 'list-style-type: disc$0'
+    'body': 'list-style-type: disc'
   'list-style-type: lower-roman':
     'prefix': 'listlr'
-    'body': 'list-style-type: lower-roman$0'
+    'body': 'list-style-type: lower-roman'
   'list-style-type: none':
     'prefix': 'listn'
-    'body': 'list-style-type: none$0'
+    'body': 'list-style-type: none'
   'list-style-type: square':
     'prefix': 'lists'
-    'body': 'list-style-type: square$0'
+    'body': 'list-style-type: square'
   'list-style-type: upper-roman':
     'prefix': 'listur'
-    'body': 'list-style-type: upper-roman$0'
+    'body': 'list-style-type: upper-roman'
   'left':
     'prefix': 'left'
-    'body': 'left: ${1:0}$0'
+    'body': 'left: ${1:0}'
   'left (shorthand)':
     'prefix': 'lef'
-    'body': 'left: ${1:0}$0'
+    'body': 'left: ${1:0}'
   'line-height':
     'prefix': 'lh'
-    'body': 'line-height: ${1:${2:1}${3:em}}$0'
+    'body': 'line-height: ${1:${2:1}${3:em}}'
   'letter-spacing':
     'prefix': 'ls'
-    'body': 'letter-spacing: ${1:${2:1}${3:px}}$0'
+    'body': 'letter-spacing: ${1:${2:1}${3:px}}'
   'letter-spacing: normal':
     'prefix': 'lsn'
-    'body': 'letter-spacing: normal$0'
+    'body': 'letter-spacing: normal'
   'margin':
     'prefix': 'mar'
-    'body': 'margin: ${1:${2:1}${3:px}}$0'
+    'body': 'margin: ${1:${2:1}${3:px}}'
   'margin-bottom':
     'prefix': 'marb'
-    'body': 'margin-bottom: ${1:${2:1}${3:px}}$0'
+    'body': 'margin-bottom: ${1:${2:1}${3:px}}'
   'margin-left':
     'prefix': 'marl'
-    'body': 'margin-left: ${1:${2:1}${3:px}}$0'
+    'body': 'margin-left: ${1:${2:1}${3:px}}'
   'margin-right':
     'prefix': 'marr'
-    'body': 'margin-right: ${1:${2:1}${3:px}}$0'
+    'body': 'margin-right: ${1:${2:1}${3:px}}'
   'margin-top':
     'prefix': 'mart'
-    'body': 'margin-top: ${1:${2:1}${3:px}}$0'
+    'body': 'margin-top: ${1:${2:1}${3:px}}'
   'min-height':
     'prefix': 'mh'
-    'body': 'min-height: ${1:${2:1}${3:px}}$0'
+    'body': 'min-height: ${1:${2:1}${3:px}}'
   'min-width':
     'prefix': 'mw'
-    'body': 'min-width: ${1:${2:1}${3:px}}$0'
+    'body': 'min-width: ${1:${2:1}${3:px}}'
   'overflow':
     'prefix': 'ov'
-    'body': 'overflow: ${1:hidden}$0'
+    'body': 'overflow: ${1:hidden}'
   'overflow: auto':
     'prefix': 'ova'
-    'body': 'overflow: auto$0'
+    'body': 'overflow: auto'
   'overflow: hidden':
     'prefix': 'ovh'
-    'body': 'overflow: hidden$0'
+    'body': 'overflow: hidden'
   'overflow: scroll':
     'prefix': 'ovs'
-    'body': 'overflow: scroll$0'
+    'body': 'overflow: scroll'
   'overflow: visible':
     'prefix': 'ovv'
-    'body': 'overflow: visible$0'
+    'body': 'overflow: visible'
   'padding':
     'prefix': 'pad'
-    'body': 'padding: ${1:${2:1}${3:px}}$0'
+    'body': 'padding: ${1:${2:1}${3:px}}'
   'padding-bottom':
     'prefix': 'padb'
-    'body': 'padding-bottom: ${1:${2:1}${3:px}}$0'
+    'body': 'padding-bottom: ${1:${2:1}${3:px}}'
   'padding-left':
     'prefix': 'padl'
-    'body': 'padding-left: ${1:${2:1}${3:px}}$0'
+    'body': 'padding-left: ${1:${2:1}${3:px}}'
   'padding-right':
     'prefix': 'padr'
-    'body': 'padding-right: ${1:${2:1}${3:px}}$0'
+    'body': 'padding-right: ${1:${2:1}${3:px}}'
   'padding-top':
     'prefix': 'padt'
-    'body': 'padding-top: ${1:${2:1}${3:px}}$0'
+    'body': 'padding-top: ${1:${2:1}${3:px}}'
   'position':
     'prefix': 'pos'
-    'body': 'position: ${1:relative}$0'
+    'body': 'position: ${1:relative}'
   'position absolute':
     'prefix': 'posa'
-    'body': 'position: absolute$0'
+    'body': 'position: absolute'
   'position fixed':
     'prefix': 'posf'
-    'body': 'position: fixed$0'
+    'body': 'position: fixed'
   'position relative':
     'prefix': 'posr'
-    'body': 'position: relative$0'
+    'body': 'position: relative'
   'position static':
     'prefix': 'poss'
-    'body': 'position: static$0'
+    'body': 'position: static'
   'right':
     'prefix': 'rig'
-    'body': 'right: ${1:0}$0'
+    'body': 'right: ${1:0}'
   'text-align':
     'prefix': 'ta'
-    'body': 'text-align: ${1:center}$0'
+    'body': 'text-align: ${1:center}'
   'text-align: center':
     'prefix': 'tac'
-    'body': 'text-align: center$0'
+    'body': 'text-align: center'
   'text-align: left':
     'prefix': 'tal'
-    'body': 'text-align: left$0'
+    'body': 'text-align: left'
   'text-align: right':
     'prefix': 'tar'
-    'body': 'text-align: right$0'
+    'body': 'text-align: right'
   'text-decoration':
     'prefix': 'td'
-    'body': 'text-decoration: ${1:underline}$0'
+    'body': 'text-decoration: ${1:underline}'
   'text-decoration: underline':
     'prefix': 'tdu'
-    'body': 'text-decoration: underline$0'
+    'body': 'text-decoration: underline'
   'text-decoration: none':
     'prefix': 'tdn'
-    'body': 'text-decoration: none$0'
+    'body': 'text-decoration: none'
   'text-transform':
     'prefix': 'tt'
-    'body': 'text-transform: ${1:uppercase}$0'
+    'body': 'text-transform: ${1:uppercase}'
   'text-transform: capitalize':
     'prefix': 'ttc'
-    'body': 'text-transform: ${1:capitalize}$0'
+    'body': 'text-transform: ${1:capitalize}'
   'text-transform: lowercase':
     'prefix': 'ttl'
-    'body': 'text-transform: ${1:lowercase}$0'
+    'body': 'text-transform: ${1:lowercase}'
   'text-transform: none':
     'prefix': 'ttn'
-    'body': 'text-transform: ${1:none}$0'
+    'body': 'text-transform: ${1:none}'
   'text-transform: uppercase':
     'prefix': 'ttu'
-    'body': 'text-transform: ${1:uppercase}$0'
+    'body': 'text-transform: ${1:uppercase}'
   'top':
     'prefix': 'top'
-    'body': 'top: ${1:0}$0'
+    'body': 'top: ${1:0}'
   'vertical-align':
     'prefix': 'va'
-    'body': 'vertical-align: ${1:middle}$0'
+    'body': 'vertical-align: ${1:middle}'
   'vertical-align: bottom':
     'prefix': 'vab'
-    'body': 'vertical-align: bottom$0'
+    'body': 'vertical-align: bottom'
   'vertical-align: middle':
     'prefix': 'vam'
-    'body': 'vertical-align: middle$0'
+    'body': 'vertical-align: middle'
   'vertical-align: top':
     'prefix': 'vat'
-    'body': 'vertical-align: top$0'
+    'body': 'vertical-align: top'
   'white-space':
     'prefix': 'ws'
-    'body': 'white-space: ${1:nowrap}$0'
+    'body': 'white-space: ${1:nowrap}'
   'white-space: nowrap':
     'prefix': 'wsn'
-    'body': 'white-space: nowrap$0'
+    'body': 'white-space: nowrap'
   'white-space: normal':
     'prefix': 'wsnor'
-    'body': 'white-space: normal$0'
+    'body': 'white-space: normal'
   'white-space: pre':
     'prefix': 'wsp'
-    'body': 'white-space: pre$0'
+    'body': 'white-space: pre'
   'width':
     'prefix': 'wid'
-    'body': 'width: ${1:${2:1}${3:px}}$0'
+    'body': 'width: ${1:${2:1}${3:px}}'
   'width: auto':
     'prefix': 'wida'
-    'body': 'width: auto$0'
+    'body': 'width: auto'
   'z-index':
     'prefix': 'zi'
-    'body': 'z-index: ${1:1}$0'
+    'body': 'z-index: ${1:1}'
 
 '.source.css, .source.scss, .source.css.scss, .source.less, .source.css.less':
   'background':
     'prefix': 'bg'
-    'body': 'background: ${1:#${2:ffffff}};$0'
+    'body': 'background: ${1:#${2:ffffff}};'
   'background-color':
     'prefix': 'bgc'
-    'body': 'background-color: ${1:#${2:ffffff}};$0'
+    'body': 'background-color: ${1:#${2:ffffff}};'
   'background-image':
     'prefix': 'bgi'
-    'body': 'background-image: ${2:url(\'${1:background.jpg}\')};$0'
+    'body': 'background-image: ${2:url(\'${1:background.jpg}\')};'
   'background-image (asset-url)':
     'prefix': 'bgia'
-    'body': 'background-image: ${2:asset-url(\'${1:background.jpg}\')};$0'
+    'body': 'background-image: ${2:asset-url(\'${1:background.jpg}\')};'
   'background-position':
     'prefix': 'bgp'
-    'body': 'background-position: ${1:left} ${2:top};$0'
+    'body': 'background-position: ${1:left} ${2:top};'
   'background-repeat':
     'prefix': 'bgr'
-    'body': 'background-repeat: ${1:repeat};$0'
+    'body': 'background-repeat: ${1:repeat};'
   'background-repeat: repeat':
     'prefix': 'bgrr'
-    'body': 'background-repeat: repeat;$0'
+    'body': 'background-repeat: repeat;'
   'background-repeat: repeat-x':
     'prefix': 'bgrx'
-    'body': 'background-repeat: repeat-x;$0'
+    'body': 'background-repeat: repeat-x;'
   'background-repeat: repeat-y':
     'prefix': 'bgry'
-    'body': 'background-repeat: repeat-y;$0'
+    'body': 'background-repeat: repeat-y;'
   'background-repeat: no-repeat':
     'prefix': 'bgrn'
-    'body': 'background-repeat: no-repeat;$0'
+    'body': 'background-repeat: no-repeat;'
   'background-size':
     'prefix': 'bgs'
-    'body': 'background-size: ${1:cover};$0'
+    'body': 'background-size: ${1:cover};'
   'border':
     'prefix': 'bor'
-    'body': 'border: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}};$0'
+    'body': 'border: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}};'
   'border-color':
     'prefix': 'borc'
-    'body': 'border-color: ${1:#${2:000}};$0'
+    'body': 'border-color: ${1:#${2:000}};'
   'border-style':
     'prefix': 'bors'
-    'body': 'border-style: ${3:solid};$0'
+    'body': 'border-style: ${3:solid};'
   'border-width':
     'prefix': 'borw'
-    'body': 'border-width: ${1:${2:1}${3:px}};$0'
+    'body': 'border-width: ${1:${2:1}${3:px}};'
   'border-bottom':
     'prefix': 'borb'
-    'body': 'border-bottom: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}};$0'
+    'body': 'border-bottom: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}};'
   'border-bottom-width':
     'prefix': 'borbw'
-    'body': 'border-bottom-width: ${1:${2:1}${3:px}};$0'
+    'body': 'border-bottom-width: ${1:${2:1}${3:px}};'
   'border-left':
     'prefix': 'borl'
-    'body': 'border-left: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}};$0'
+    'body': 'border-left: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}};'
   'border-left-width':
     'prefix': 'borlw'
-    'body': 'border-left-width: ${1:${2:1}${3:px}};$0'
+    'body': 'border-left-width: ${1:${2:1}${3:px}};'
   'border-right':
     'prefix': 'borr'
-    'body': 'border-right: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}};$0'
+    'body': 'border-right: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}};'
   'border-right-width':
     'prefix': 'borrw'
-    'body': 'border-right-width: ${1:${2:1}${3:px}};$0'
+    'body': 'border-right-width: ${1:${2:1}${3:px}};'
   'border-top':
     'prefix': 'bort'
-    'body': 'border-top: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}};$0'
+    'body': 'border-top: ${1:${2:1}${3:px}} ${3:solid} ${4:#${5:000}};'
   'border-top-width':
     'prefix': 'bortw'
-    'body': 'border-top-width: ${1:${2:1}${3:px}};$0'
+    'body': 'border-top-width: ${1:${2:1}${3:px}};'
   'border-radius':
     'prefix': 'br'
-    'body': 'border-radius: ${1:${2:1}${3:px}};$0'
+    'body': 'border-radius: ${1:${2:1}${3:px}};'
   'bottom':
     'prefix': 'bot'
-    'body': 'bottom: ${1:0};$0'
+    'body': 'bottom: ${1:0};'
   'box-shadow':
     'prefix': 'boxs'
     'body': 'box-shadow: ${1:0px} ${2:3px} ${3:15px} ${4:1px} ${5:rgba(0,0,0,.5)};$0     // h-length, v-length, blur, spread, colour'
   'clear':
     'prefix': 'clr'
-    'body': 'clear: ${1:both};$0'
+    'body': 'clear: ${1:both};'
   'color':
     'prefix': 'col'
-    'body': 'color: ${1:#${2:000000}};$0'
+    'body': 'color: ${1:#${2:000000}};'
   'content':
     'prefix': 'con'
     'body': "content: '$1';$0"
   'cursor':
     'prefix': 'cur'
-    'body': 'cursor: ${1:pointer};$0'
+    'body': 'cursor: ${1:pointer};'
   'cursor: pointer':
     'prefix': 'curp'
-    'body': 'cursor: pointer;$0'
+    'body': 'cursor: pointer;'
   'cursor: default':
     'prefix': 'curd'
-    'body': 'cursor: default;$0'
+    'body': 'cursor: default;'
   'cursor: inherit':
     'prefix': 'curi'
-    'body': 'cursor: inherit;$0'
+    'body': 'cursor: inherit;'
   'display':
     'prefix': 'dis'
-    'body': 'display: ${1:none};$0'
+    'body': 'display: ${1:none};'
   'display: block':
     'prefix': 'disb'
-    'body': 'display: block;$0'
+    'body': 'display: block;'
   'display: inline-block':
     'prefix': 'disi'
-    'body': 'display: inline-block;$0'
+    'body': 'display: inline-block;'
   'display: none':
     'prefix': 'disn'
-    'body': 'display: none;$0'
+    'body': 'display: none;'
   'display: flex':
     'prefix': 'disf'
-    'body': 'display: flex;$0'
+    'body': 'display: flex;'
   'fill':
     'prefix': 'fill'
-    'body': 'fill: ${1:#${2:000000}};$0'
+    'body': 'fill: ${1:#${2:000000}};'
   'float':
     'prefix': 'fl'
-    'body': 'float: ${1:left};$0'
+    'body': 'float: ${1:left};'
   'float: left':
     'prefix': 'fll'
-    'body': 'float: left;$0'
+    'body': 'float: left;'
   'float: right':
     'prefix': 'flr'
-    'body': 'float: right;$0'
+    'body': 'float: right;'
   'float: none':
     'prefix': 'fln'
-    'body': 'float: none;$0'
+    'body': 'float: none;'
   'font-family':
     'prefix': 'ff'
-    'body': 'font-family: ${1:arial};$0'
+    'body': 'font-family: ${1:arial};'
   'font-size':
     'prefix': 'fs'
-    'body': 'font-size: ${1:${2:1}${3:px}};$0'
+    'body': 'font-size: ${1:${2:1}${3:px}};'
   'font-style':
     'prefix': 'fst'
-    'body': 'font-style: ${1:italic};$0'
+    'body': 'font-style: ${1:italic};'
   'font-style: italic':
     'prefix': 'fsti'
-    'body': 'font-style: italic;$0'
+    'body': 'font-style: italic;'
   'font-style: normal':
     'prefix': 'fstn'
-    'body': 'font-style: normal;$0'
+    'body': 'font-style: normal;'
   'font-style: bold':
     'prefix': 'fstb'
-    'body': 'font-style: bold;$0'
+    'body': 'font-style: bold;'
   'font-weight':
     'prefix': 'fw'
-    'body': 'font-weight: ${1:bold};$0'
+    'body': 'font-weight: ${1:bold};'
   'font-weight: bold':
     'prefix': 'fwb'
-    'body': 'font-weight: bold;$0'
+    'body': 'font-weight: bold;'
   'font-weight: light':
     'prefix': 'fwl'
-    'body': 'font-weight: light;$0'
+    'body': 'font-weight: light;'
   'font-weight: normal':
     'prefix': 'fwn'
-    'body': 'font-weight: normal;$0'
+    'body': 'font-weight: normal;'
   'height':
     'prefix': 'hei'
-    'body': 'height: ${1:${2:1}${3:px}};$0'
+    'body': 'height: ${1:${2:1}${3:px}};'
   'height: auto':
     'prefix': 'heia'
-    'body': 'height: auto;$0'
+    'body': 'height: auto;'
   'list-style':
     'prefix': 'lis'
-    'body': 'list-style: ${1:square} ${2:inside} ${4:url(\'${3:list.png}\')};$0'
+    'body': 'list-style: ${1:square} ${2:inside} ${4:url(\'${3:list.png}\')};'
   'list-style-type':
     'prefix': 'list'
-    'body': 'list-style-type: ${1:circle};$0'
+    'body': 'list-style-type: ${1:circle};'
   'list-style-type: circle':
     'prefix': 'listc'
-    'body': 'list-style-type: circle;$0'
+    'body': 'list-style-type: circle;'
   'list-style-type: disc':
     'prefix': 'listd'
-    'body': 'list-style-type: disc;$0'
+    'body': 'list-style-type: disc;'
   'list-style-type: lower-roman':
     'prefix': 'listlr'
-    'body': 'list-style-type: lower-roman;$0'
+    'body': 'list-style-type: lower-roman;'
   'list-style-type: none':
     'prefix': 'listn'
-    'body': 'list-style-type: none;$0'
+    'body': 'list-style-type: none;'
   'list-style-type: square':
     'prefix': 'lists'
-    'body': 'list-style-type: square;$0'
+    'body': 'list-style-type: square;'
   'list-style-type: upper-roman':
     'prefix': 'listur'
-    'body': 'list-style-type: upper-roman;$0'
+    'body': 'list-style-type: upper-roman;'
   'left':
     'prefix': 'left'
-    'body': 'left: ${1:0};$0'
+    'body': 'left: ${1:0};'
   'left (shorthand)':
     'prefix': 'lef'
-    'body': 'left: ${1:0};$0'
+    'body': 'left: ${1:0};'
   'line-height':
     'prefix': 'lh'
-    'body': 'line-height: ${1:${2:1}${3:em}};$0'
+    'body': 'line-height: ${1:${2:1}${3:em}};'
   'letter-spacing':
     'prefix': 'ls'
-    'body': 'letter-spacing: ${1:${2:1}${3:px}};$0'
+    'body': 'letter-spacing: ${1:${2:1}${3:px}};'
   'letter-spacing: normal':
     'prefix': 'lsn'
-    'body': 'letter-spacing: normal;$0'
+    'body': 'letter-spacing: normal;'
   'margin':
     'prefix': 'mar'
-    'body': 'margin: ${1:${2:1}${3:px}};$0'
+    'body': 'margin: ${1:${2:1}${3:px}};'
   'margin-bottom':
     'prefix': 'marb'
-    'body': 'margin-bottom: ${1:${2:1}${3:px}};$0'
+    'body': 'margin-bottom: ${1:${2:1}${3:px}};'
   'margin-left':
     'prefix': 'marl'
-    'body': 'margin-left: ${1:${2:1}${3:px}};$0'
+    'body': 'margin-left: ${1:${2:1}${3:px}};'
   'margin-right':
     'prefix': 'marr'
-    'body': 'margin-right: ${1:${2:1}${3:px}};$0'
+    'body': 'margin-right: ${1:${2:1}${3:px}};'
   'margin-top':
     'prefix': 'mart'
-    'body': 'margin-top: ${1:${2:1}${3:px}};$0'
+    'body': 'margin-top: ${1:${2:1}${3:px}};'
   'min-height':
     'prefix': 'mh'
-    'body': 'min-height: ${1:${2:1}${3:px}};$0'
+    'body': 'min-height: ${1:${2:1}${3:px}};'
   'min-width':
     'prefix': 'mw'
-    'body': 'min-width: ${1:${2:1}${3:px}};$0'
+    'body': 'min-width: ${1:${2:1}${3:px}};'
   'overflow':
     'prefix': 'ov'
-    'body': 'overflow: ${1:hidden};$0'
+    'body': 'overflow: ${1:hidden};'
   'overflow: auto':
     'prefix': 'ova'
-    'body': 'overflow: auto;$0'
+    'body': 'overflow: auto;'
   'overflow: hidden':
     'prefix': 'ovh'
-    'body': 'overflow: hidden;$0'
+    'body': 'overflow: hidden;'
   'overflow: scroll':
     'prefix': 'ovs'
-    'body': 'overflow: scroll;$0'
+    'body': 'overflow: scroll;'
   'overflow: visible':
     'prefix': 'ovv'
-    'body': 'overflow: visible;$0'
+    'body': 'overflow: visible;'
   'padding':
     'prefix': 'pad'
-    'body': 'padding: ${1:${2:1}${3:px}};$0'
+    'body': 'padding: ${1:${2:1}${3:px}};'
   'padding-bottom':
     'prefix': 'padb'
-    'body': 'padding-bottom: ${1:${2:1}${3:px}};$0'
+    'body': 'padding-bottom: ${1:${2:1}${3:px}};'
   'padding-left':
     'prefix': 'padl'
-    'body': 'padding-left: ${1:${2:1}${3:px}};$0'
+    'body': 'padding-left: ${1:${2:1}${3:px}};'
   'padding-right':
     'prefix': 'padr'
-    'body': 'padding-right: ${1:${2:1}${3:px}};$0'
+    'body': 'padding-right: ${1:${2:1}${3:px}};'
   'padding-top':
     'prefix': 'padt'
-    'body': 'padding-top: ${1:${2:1}${3:px}};$0'
+    'body': 'padding-top: ${1:${2:1}${3:px}};'
   'position':
     'prefix': 'pos'
-    'body': 'position: ${1:relative};$0'
+    'body': 'position: ${1:relative};'
   'position absolute':
     'prefix': 'posa'
-    'body': 'position: absolute;$0'
+    'body': 'position: absolute;'
   'position fixed':
     'prefix': 'posf'
-    'body': 'position: fixed;$0'
+    'body': 'position: fixed;'
   'position relative':
     'prefix': 'posr'
-    'body': 'position: relative;$0'
+    'body': 'position: relative;'
   'position static':
     'prefix': 'poss'
-    'body': 'position: static;$0'
+    'body': 'position: static;'
   'right':
     'prefix': 'rig'
-    'body': 'right: ${1:0};$0'
+    'body': 'right: ${1:0};'
   'text-align':
     'prefix': 'ta'
-    'body': 'text-align: ${1:center};$0'
+    'body': 'text-align: ${1:center};'
   'text-align: center':
     'prefix': 'tac'
-    'body': 'text-align: center;$0'
+    'body': 'text-align: center;'
   'text-align: left':
     'prefix': 'tal'
-    'body': 'text-align: left;$0'
+    'body': 'text-align: left;'
   'text-align: right':
     'prefix': 'tar'
-    'body': 'text-align: right;$0'
+    'body': 'text-align: right;'
   'text-decoration':
     'prefix': 'td'
-    'body': 'text-decoration: ${1:underline};$0'
+    'body': 'text-decoration: ${1:underline};'
   'text-decoration: underline':
     'prefix': 'tdu'
-    'body': 'text-decoration: underline;$0'
+    'body': 'text-decoration: underline;'
   'text-decoration: none':
     'prefix': 'tdn'
-    'body': 'text-decoration: none;$0'
+    'body': 'text-decoration: none;'
   'text-transform':
     'prefix': 'tt'
-    'body': 'text-transform: ${1:uppercase};$0'
+    'body': 'text-transform: ${1:uppercase};'
   'text-transform: capitalize':
     'prefix': 'ttc'
-    'body': 'text-transform: ${1:capitalize};$0'
+    'body': 'text-transform: ${1:capitalize};'
   'text-transform: lowercase':
     'prefix': 'ttl'
-    'body': 'text-transform: ${1:lowercase};$0'
+    'body': 'text-transform: ${1:lowercase};'
   'text-transform: none':
     'prefix': 'ttn'
-    'body': 'text-transform: ${1:none};$0'
+    'body': 'text-transform: ${1:none};'
   'text-transform: uppercase':
     'prefix': 'ttu'
-    'body': 'text-transform: ${1:uppercase};$0'
+    'body': 'text-transform: ${1:uppercase};'
   'top':
     'prefix': 'top'
-    'body': 'top: ${1:0};$0'
+    'body': 'top: ${1:0};'
   'vertical-align':
     'prefix': 'va'
-    'body': 'vertical-align: ${1:middle};$0'
+    'body': 'vertical-align: ${1:middle};'
   'vertical-align: bottom':
     'prefix': 'vab'
-    'body': 'vertical-align: bottom;$0'
+    'body': 'vertical-align: bottom;'
   'vertical-align: middle':
     'prefix': 'vam'
-    'body': 'vertical-align: middle;$0'
+    'body': 'vertical-align: middle;'
   'vertical-align: top':
     'prefix': 'vat'
-    'body': 'vertical-align: top;$0'
+    'body': 'vertical-align: top;'
   'white-space':
     'prefix': 'ws'
-    'body': 'white-space: ${1:nowrap};$0'
+    'body': 'white-space: ${1:nowrap};'
   'white-space: nowrap':
     'prefix': 'wsn'
-    'body': 'white-space: nowrap;$0'
+    'body': 'white-space: nowrap;'
   'white-space: normal':
     'prefix': 'wsnor'
-    'body': 'white-space: normal;$0'
+    'body': 'white-space: normal;'
   'white-space: pre':
     'prefix': 'wsp'
-    'body': 'white-space: pre;$0'
+    'body': 'white-space: pre;'
   'width':
     'prefix': 'wid'
-    'body': 'width: ${1:${2:1}${3:px}};$0'
+    'body': 'width: ${1:${2:1}${3:px}};'
   'width: auto':
     'prefix': 'wida'
-    'body': 'width: auto;$0'
+    'body': 'width: auto;'
   'z-index':
     'prefix': 'zi'
-    'body': 'z-index: ${1:1};$0'
+    'body': 'z-index: ${1:1};'
 
 '.source.css, .source.scss, .source.css.scss, .source.less, .source.css.less, .source.sass, .source.css.sass':
   '!important':
     'prefix': '!'
-    'body': '!important$0'
+    'body': '!important'


### PR DESCRIPTION
Adding a **box-shadow** property as I keep having to Google the parameter order, bonus that this also addresses one of the three support issues https://github.com/dsandstrom/atom-css-snippets/issues/18

Default parameter outputs put a Material Design-style card shadow emphasising the container "floating".

Also outputs a comment at the end of the line with the parameters for reference.