### PR TITLE
Replace font-style: `bold` with `oblique`

### DIFF
--- a/snippets/css-snippets.cson
+++ b/snippets/css-snippets.cson
@@ -627,9 +627,9 @@
   'font-style: normal':
     'prefix': 'fstn'
     'body': 'font-style: normal;'
-  'font-style: bold':
-    'prefix': 'fstb'
-    'body': 'font-style: bold;'
+  'font-style: oblique':
+    'prefix': 'fsto'
+    'body': 'font-style: oblique;'
   'font-weight':
     'prefix': 'fw'
     'body': 'font-weight: ${1:bold};'

--- a/snippets/css-snippets.cson
+++ b/snippets/css-snippets.cson
@@ -186,9 +186,9 @@
   'font-style: normal':
     'prefix': 'fstn'
     'body': 'font-style: normal'
-  'font-style: bold':
-    'prefix': 'fstb'
-    'body': 'font-style: bold'
+  'font-style: oblique':
+    'prefix': 'fsto'
+    'body': 'font-style: oblique'
   'font-weight':
     'prefix': 'fw'
     'body': 'font-weight: ${1:bold}'


### PR DESCRIPTION
`font-style` can only be `normal`, `italic` or `oblique` not `bold`.
See: https://developer.mozilla.org/de/docs/Web/CSS/font-style